### PR TITLE
fix(frontend): Detail widget for best content result is incorrect.

### DIFF
--- a/src/content-widget.cpp
+++ b/src/content-widget.cpp
@@ -235,7 +235,18 @@ void ContentWidget::hideListView()
 void ContentWidget::setupConnect(SearchListView * listview) {
     connect(listview, &SearchListView::currentRowChanged, this, [ = ](const int& type, const QString& path) {
         if(type == SearchItem::SearchType::Contents && !m_contentDetailList.isEmpty()) {
+            m_detailView->isContent = true;
             m_detailView->setContent(m_contentDetailList.at(listview->currentIndex().row()), m_keyword);
+        } else if (type == SearchItem::SearchType::Best && !m_bestContent.isEmpty() && listview->currentIndex().row() == listview->getLength() - 1) {
+            m_detailView->setContent(m_bestContent, m_keyword);
+            m_detailView->isContent = true;
+            m_detailView->setupWidget(type == SearchItem::SearchType::Contents, path);
+            listview->is_current_list = true;
+            Q_EMIT this->currentItemChanged();
+            listview->is_current_list = false;
+            return;
+        } else {
+            m_detailView->isContent = false;
         }
         m_detailView->setupWidget(type, path);
 //        m_detailView->setWebWidget(this->m_keyword);
@@ -434,6 +445,7 @@ void ContentWidget::refreshSearchList(const QVector<QStringList>& lists) {
     m_resultList->setFixedHeight(0);
     m_detailView->clearLayout();
     m_contentDetailList.clear();
+    m_bestContent.clear();
 
     m_appShowMoreLabel->resetLabel();
     m_settingShowMoreLabel->resetLabel();
@@ -566,6 +578,12 @@ void ContentWidget::appendSearchItem(const int& type, const QString& path, QStri
                 m_contentListView->show();
                 m_contentTitleLabel->show();
                 m_contentListView->isHidden = false;
+                for (int i = 0; i < contents.length(); i ++) {
+                    m_bestContent.append(contents.at(i));
+                    if (i != contents.length() - 1) {
+                        m_bestContent.append("\n");
+                    }
+                }
                 appendSearchItem(SearchItem::SearchType::Best, path);
             }
             if (m_contentListView->getLength() < 5) {

--- a/src/content-widget.h
+++ b/src/content-widget.h
@@ -91,6 +91,8 @@ private:
     QStringList m_contentList;
     QStringList m_quicklyOpenList;
 
+    QString m_bestContent; //最佳匹配有文件内容搜索结果的时候，以此变量传递
+
     int m_currentType = 0;
 
     QString getTitleName(const int&);

--- a/src/control/option-view.cpp
+++ b/src/control/option-view.cpp
@@ -67,6 +67,7 @@ void OptionView::setupOptions(const int& type) {
             break;
         }
         case SearchListView::ResType::Content:
+        case SearchListView::ResType::Best:
         case SearchListView::ResType::File : {
             setupFileOptions();
             break;

--- a/src/control/search-detail-view.cpp
+++ b/src/control/search-detail-view.cpp
@@ -177,9 +177,9 @@ void SearchDetailView::setupWidget(const int& type, const QString& path) {
     m_hLine->show();
 
     //文件和文件夹有一个额外的详情区域
-    if (type == SearchListView::ResType::Dir || type == SearchListView::ResType::File || type == SearchListView::ResType::Content) {
+    if (type == SearchListView::ResType::Dir || type == SearchListView::ResType::File || type == SearchListView::ResType::Content || type == SearchListView::ResType::Best) {
         m_detailFrame->show();
-        if (type == SearchListView::ResType::Content) { //文件内容区域
+        if (isContent) { //文件内容区域
             m_contentLabel->show();
             m_contentLabel->setText(QApplication::translate("", getHtmlText(m_contentText, m_keyword).toLocal8Bit(), nullptr));
         }
@@ -190,14 +190,14 @@ void SearchDetailView::setupWidget(const int& type, const QString& path) {
 //        m_pathLabel_2->setText(path);
         QString showPath = path;
         QFontMetrics fontMetrics = m_pathLabel_2->fontMetrics();
-        if (fontMetrics.width(path) > m_pathLabel_2->width()) {
-            //路径长度超过240,手动添加换行符以实现折叠
+        if (fontMetrics.width(path) > m_pathLabel_2->width() - 10) {
+            //路径长度超过230,手动添加换行符以实现折叠
             int lastIndex = 0;
             for (int i = lastIndex; i < path.length(); i++) {
-                if (fontMetrics.width(path.mid(lastIndex, i - lastIndex)) == m_pathLabel_2->width()) {
+                if (fontMetrics.width(path.mid(lastIndex, i - lastIndex)) == m_pathLabel_2->width() - 10) {
                     lastIndex = i;
                     showPath.insert(i, '\n');
-                } else if (fontMetrics.width(path.mid(lastIndex, i - lastIndex)) > m_pathLabel_2->width()) {
+                } else if (fontMetrics.width(path.mid(lastIndex, i - lastIndex)) > m_pathLabel_2->width() - 10) {
                     lastIndex = i;
                     showPath.insert(i - 1, '\n');
                 } else {
@@ -233,6 +233,7 @@ void SearchDetailView::setupWidget(const int& type, const QString& path) {
             break;
         }
         case SearchListView::ResType::Content:
+        case SearchListView::ResType::Best:
         case SearchListView::ResType::Dir :
         case SearchListView::ResType::File : {
             QIcon icon = FileUtils::getFileIcon(QString("file://%1").arg(path));

--- a/src/control/search-detail-view.h
+++ b/src/control/search-detail-view.h
@@ -37,6 +37,7 @@ public:
     void setContent(const QString&, const QString&);
     bool isEmpty();
     int getType();
+    bool isContent = false;
 //    void setWebWidget(const QString&);
 
 protected:

--- a/src/control/search-list-view.cpp
+++ b/src/control/search-list-view.cpp
@@ -160,7 +160,8 @@ int SearchListView::getResType(const QString& path) {
         return SearchListView::ResType::App;
     } else if (QFileInfo(path).isFile()) {
 //        qDebug()<<"qDebug: One row selected, its path is "<<path<<". Its type is file.";
-        return SearchListView::ResType::File;
+//        return SearchListView::ResType::File;
+        return SearchListView::ResType::Best;
     } else if (QFileInfo(path).isDir()) {
 //        qDebug()<<"qDebug: One row selected, its path is "<<path<<". Its type is dir.";
         return SearchListView::ResType::Dir;


### PR DESCRIPTION
Log: 修复最佳匹配里的文件内容项显示有误的问题
Log: 修复文件路径过长显示有截断的问题
Bug: http://172.17.66.192/biz/bug-view-35563.html
        http://172.17.66.192/biz/bug-view-35971.html