### PR TITLE
Make search result list scrolling with current selection item changing when key_up and key_down pressed.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ukui-search (0.2.0+0325) v101; urgency=medium
+
+  * Changed name displayed in ukui-menu from 'ukui-search' to 'Search'.
+    - 更改了英文模式下开始菜单中显示的名字。
+
+ -- zhangpengfei <zhangpengfei@kylinos.cn>  Thu, 25 Mar 2021 11:00:09 +0800
+
 ukui-search (0.2.0+0322) v101; urgency=medium
 
   * Fit muti-screens mode. 

--- a/src/content-widget.cpp
+++ b/src/content-widget.cpp
@@ -300,6 +300,9 @@ void ContentWidget::setupConnect(SearchListView * listview) {
             listview->blockSignals(false);
         }
     });
+    connect(listview,&SearchListView::currentSelectPos,[=](QPoint pos){
+        m_resultListArea->ensureVisible(pos.x(),pos.y());
+    });
 }
 
 /**

--- a/src/control/search-list-view.cpp
+++ b/src/control/search-list-view.cpp
@@ -45,9 +45,15 @@ SearchListView::SearchListView(QWidget * parent, const QStringList& list, const 
     this->setItemDelegate(m_styleDelegate);
 
     m_type = type;
-    connect(this->selectionModel(), &QItemSelectionModel::selectionChanged, this, [ = ]() {
+    connect(this->selectionModel(), &QItemSelectionModel::selectionChanged, this, [ = ](const QItemSelection &selected, const QItemSelection &deselected) {
         Q_EMIT this->currentRowChanged(getCurrentType(), m_item->m_pathlist.at(this->currentIndex().row()));
         m_isSelected = true;
+        if(!selected.isEmpty())
+        {
+            QRegion region = visualRegionForSelection(selected);
+            QRect rect = region.boundingRect();
+            Q_EMIT this->currentSelectPos(mapToParent(rect.topLeft()));
+        }
     });
 
     connect(this, &SearchListView::doubleClicked, this, [ = ](const QModelIndex& index) {

--- a/src/control/search-list-view.h
+++ b/src/control/search-list-view.h
@@ -71,6 +71,7 @@ private:
 
 Q_SIGNALS:
     void currentRowChanged(const int&, const QString&);
+    void currentSelectPos(QPoint pos);
 
 public Q_SLOTS:
     void clearSelection();


### PR DESCRIPTION
Update changelog;
Make search result list scrolling with current selection item changing when key_up and key_down pressed.