### PR TITLE
[Fix] Sometimes file icon wouldn't be displayed correctly if name of the file contians special symbols.

### DIFF
--- a/src/control/home-page-item.cpp
+++ b/src/control/home-page-item.cpp
@@ -77,7 +77,7 @@ void HomePageItem::setupUi(const int& type, const QString& path) {
         case SearchListView::ResType::Content:
         case SearchListView::ResType::Dir :
         case SearchListView::ResType::File : {
-            icon = FileUtils::getFileIcon(QString("file://%1").arg(path));
+            icon = FileUtils::getFileIcon(QUrl::fromLocalFile(path).toString());
 //                m_namelabel->setText(FileUtils::getFileName(path));
             QFontMetrics fontMetrics = m_namelabel->fontMetrics();
             QString name = FileUtils::getFileName(path);

--- a/src/control/search-detail-view.cpp
+++ b/src/control/search-detail-view.cpp
@@ -351,7 +351,7 @@ void SearchDetailView::setupWidget(const int& type, const QString& path) {
     case SearchListView::ResType::Content:
     case SearchListView::ResType::Dir :
     case SearchListView::ResType::File : {
-        QIcon icon = FileUtils::getFileIcon(QString("file://%1").arg(path));
+        QIcon icon = FileUtils::getFileIcon(QUrl::fromLocalFile(path).toString());
         m_iconLabel->setPixmap(icon.pixmap(icon.actualSize(QSize(96, 96))));
         QFontMetrics fontMetrics = m_nameLabel->fontMetrics();
         QString wholeName = FileUtils::getFileName(path);

--- a/src/model/search-item.cpp
+++ b/src/model/search-item.cpp
@@ -42,7 +42,8 @@ QIcon SearchItem::getIcon(int index) {
     case Contents:
     case Dirs :
     case Files : //文件，返回文件图标
-        return FileUtils::getFileIcon(QString("file://%1").arg(m_pathlist.at(index)));
+//        return FileUtils::getFileIcon(QString("file://%1").arg(m_pathlist.at(index)));
+        return FileUtils::getFileIcon(QUrl::fromLocalFile(m_pathlist.at(index)).toString());
     case Apps : {//应用，返回应用图标
 //            return FileUtils::getAppIcon(m_pathlist.at(index));
         if(m_app_pathlist.length() > index && m_app_pathlist.at(index) == "") {  //未安装，存储的是图标路径
@@ -115,7 +116,7 @@ QIcon SearchItem::getBestIcon(const int &index) {
         return FileUtils::getSettingIcon(m_pathlist.at(index), false);
     }
     default: {
-        return FileUtils::getFileIcon(QString("file://%1").arg(m_pathlist.at(index)));
+        return FileUtils::getFileIcon(QUrl::fromLocalFile(m_pathlist.at(index)).toString());
     }
     }
 }


### PR DESCRIPTION
the file contians special symbols.